### PR TITLE
Fix ingredient deletion bug

### DIFF
--- a/backend/recipe.go
+++ b/backend/recipe.go
@@ -268,8 +268,8 @@ func UpdateRecipeDB(r *Recipe, db *sql.DB) error {
 		}
 	}
 
-	_, err = tx.Exec("DELETE FROM steps WHERE step > $1",
-		len(r.Steps)-1)
+	_, err = tx.Exec("DELETE FROM steps WHERE step > $1 AND recipe_id = $2",
+		len(r.Steps)-1, r.Id)
 	if err != nil {
 		tx.Rollback()
 		return err


### PR DESCRIPTION
Ingredients with id greater than number of ingredients in recipe were
deleted from entire database when updating said recipe.